### PR TITLE
automatic linking of internal packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@ Web Components, HTML elements in general, do not allow parameters in the constru
 Must run on es6
 
 TODO: how does 'main' in package.json work with npm-link and import 'views'
+
+#
+
+Framework knows
+
+- views
+- models
+- dependency-wrapper
+
+views knows
+
+- models
+- dependency-wrapper

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+    echo "no frontend framework selected"
+else
+    cd DependencyInjection;
+    npm i;
+    npm link;
+    cd ..;
+    cd Models;
+    npm i;
+    npm link;
+    cd ..;
+    cd Views;
+    npm i;
+    npm link;
+    npm link dependencyinjection
+    npm link models
+    cd ..;
+    cd FrontendFrameworks/"$1"
+    npm i;
+    npm link dependencyinjection
+    npm link models
+    npm link views
+
+    echo "successfully linked all dependencies"
+fi
+


### PR DESCRIPTION
manual linking of internal packages is no longer necessary
running bash start.sh in the root folder automatically links all necessary packages